### PR TITLE
Update package.json to fix issue #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,9 +73,9 @@
     "keycharm": "^0.3.1",
     "propagating-hammerjs": "^1.4.7",
     "uuid": "^7.0.0",
-    "vis-data": "^6.5.2",
-    "vis-timeline": "^7.3.6",
-    "vis-util": "^4.0.1"
+    "vis-data": "^7.1.0",
+    "vis-timeline": "^7.4.2",
+    "vis-util": "^4.3.4"
   },
   "peerDependencies": {
     "lodash": "^4.17.15",


### PR DESCRIPTION
Update vis-data vis-timeline and vis-utils to their latest and matching versions. This gets rid of the issue:

Error message:
./node_modules/vis-timeline/esnext/esm/vis-timeline-graph2d.js
Attempted import error: 'isDataViewLike' is not exported from 'vis-data/esnext/esm/vis-data.js'.

# Overview
Add general description explaining what this PR achieves

## Updates
Add high level overview of the individual changes in this PR

* e.g. Updated package to version x.x.x

## Dependencies
Add any dependencies associated with this PR e.g.

- [ ] e.g. Wait for PR to be merged

## Outstanding Tasks
Add any tasks which need to be completed before merge

- [ ] e.g. Functional testing

## Screenshots (if appropriate)
